### PR TITLE
add $SNAP/lib, $SNAP/lib/$TRIPLET to library path

### DIFF
--- a/electron-launch
+++ b/electron-launch
@@ -16,8 +16,9 @@ if test "$1" = "classic"; then
             TRIPLET="$(uname -p)-linux-gnu"
             ;;
     esac
-
-    export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET   
+   
+    export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET
+    export LD_LIBRARY_PATH=$SNAP/lib:$SNAP/lib/$TRIPLET:$LD_LIBRARY_PATH
 fi
 
 # Correct the TMPDIR path for Chromium Framework/Electron to ensure


### PR DESCRIPTION
fix launcher issue on non-16.04 systems:

/snap/atom/20/usr/share/atom/atom: error while loading shared libraries: libkeyutils.so.1: cannot open shared object file: No such file or directory