### PR TITLE
do not replace but prefix LD_LIBRARY_PATH

### DIFF
--- a/electron-launch
+++ b/electron-launch
@@ -17,7 +17,7 @@ if test "$1" = "classic"; then
             ;;
     esac
    
-    export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET
+    export LD_LIBRARY_PATH=$SNAP/usr/lib:$SNAP/usr/lib/$TRIPLET:$LD_LIBRARY_PATH
     export LD_LIBRARY_PATH=$SNAP/lib:$SNAP/lib/$TRIPLET:$LD_LIBRARY_PATH
 fi
 


### PR DESCRIPTION
The last fix to LD_LIBRARY_PATH was not enough (see https://dev.solus-project.com/T4390 ).

Instead of completely replacing the variable content we should just prefix it with the snap-delivered lib paths, so it can fall back to use available system libs (like libpcre.so.3 in the above bug)
