### PR TITLE
Add architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,9 @@ description: |
 grade: stable
 confinement: classic
 
+architectures:
+  - build-on: amd64
+
 parts:
   atom:
     install: |
@@ -23,11 +26,7 @@ parts:
     prepare: |
       sed -i 's|Icon=atom|Icon=/usr/share/pixmaps/atom\.png|g' usr/share/applications/atom.desktop
     build-packages:
-      # Atom debs are only available for amd64.
-      # Fail builds on other architectures
-      - on amd64:
-        - curl
-      - else fail
+      - curl
     stage-packages:
       - libappindicator3-1
       - libasound2


### PR DESCRIPTION
Adding the architectures stanza which means we don't waste time building on unsupported architectures. See [this thread](https://forum.snapcraft.io/t/architectures/4972) for more details.