### PR TITLE
Add the GNOME 3.26 backport PPA.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,21 +13,32 @@ architectures:
   - build-on: amd64
 
 parts:
+  gnome:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      apt -y update
+      apt -y upgrade
+
   atom:
-    install: |
+    after:
+      - gnome
+    plugin: dump
+    source: https://atom.io/download/deb
+    source-type: deb
+    override-build: |
       DEB_API="https://atom.io/download/deb"
       DEB_URL=$(curl -w "%{url_effective}\n" -I -L -s -S "${DEB_API}" -o /dev/null)
       VERSION=$(echo "${DEB_URL}" | cut -d'/' -f4 | tr -d 'v')
       echo $VERSION > $SNAPCRAFT_STAGE/version
-    plugin: dump
-    source: https://atom.io/download/deb
-    source-type: deb
-    # Correct path to icon.
-    prepare: |
+      snapcraftctl build
       sed -i 's|Icon=atom|Icon=/usr/share/pixmaps/atom\.png|g' usr/share/applications/atom.desktop
     build-packages:
       - curl
     stage-packages:
+      - fcitx-frontend-gtk3
       - libappindicator3-1
       - libasound2
       - libcurl3-gnutls


### PR DESCRIPTION
This pull request enables the GNOME 3.26 PPA supported by the Ubuntu Desktop team. This fixes access to user fonts and also theme integration. Thanks @kenvandine!