### PR TITLE
fix bash syntax

### DIFF
--- a/files/bin/launcher
+++ b/files/bin/launcher
@@ -8,7 +8,7 @@ fi
 # If we launched from a desktop file, likely this is set, so we need to 
 # set ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT which we removed from
 # the desktop file
-if [ ! -z "$BAMF_DESKTOP_FILE_HINT"]; then
+if [ ! -z "$BAMF_DESKTOP_FILE_HINT" ]; then
 	export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false
 fi
 


### PR DESCRIPTION
fixes

```
/snap/atom/.../bin/launcher: line 11: [: missing `]'
```

which appears when running e.g. `apm i ...`